### PR TITLE
FACILITY-15955 updated unserved file types

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -40,11 +40,21 @@ http {
             add_header Cache-Control "public, max-age=14400, must-revalidate";
             proxy_pass https://s3-us-west-2.amazonaws.com/img-lagunatreatment-com/wp-content/uploads/;
         }
-        
+
         # Media: images, icons, video, audio, HTC, 4 hours
-        location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|webp|htc|woff|woff2)$ {
+        location ~* \.(?:jpg|jpeg|gif|png|ico|cur|svg|svgz|mp4|ogg|ogv|webm|webp|htc|woff|woff2)$ {
             add_header Cache-Control "public, max-age=14400, must-revalidate";
             root /var/app/current;
+        }
+
+        # slow attacks by quickly returning unserved file types
+        location ~* \.(bak|zip|tar|gz|sql|php|env|aspx)$|/\. {
+             return 403;
+        }
+
+        # slow attacks by quickly returning ads.txt
+        location ~ ^/(ads\.txt)$ {
+            return 403;
         }
 
         # CSS and Javascript, 4 hours


### PR DESCRIPTION
https://recoverybrands.atlassian.net/browse/FACILITY-15955

Description:
FACILITY-15955 updated unserved file types

Example Links:
https://staging.lagunatreatment.com/test.bak
https://staging.lagunatreatment.com/test.zip
https://staging.lagunatreatment.com/test.tar
https://staging.lagunatreatment.com/test.gz
https://staging.lagunatreatment.com/test.sql
https://staging.lagunatreatment.com/test.php
https://staging.lagunatreatment.com/test.env
https://staging.lagunatreatment.com/test.aspx
https://staging.lagunatreatment.com/test.env.aspx
https://staging.lagunatreatment.com/ads.txt

Note: Only ads.txt should be blocked. We need robots.txt to load.

https://staging.lagunatreatment.com/robots.txt

Screenshot:
![image](https://github.com/American-Addiction-Centers/lagunatreatment-com-nginx/assets/86256771/5c87ac66-d891-41cd-88cc-0d599ef68c6a)